### PR TITLE
Change base image from java to openjdk

### DIFF
--- a/function-controller/Dockerfile
+++ b/function-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-alpine
 VOLUME /tmp
 ARG JAR_FILE
 ADD ./target/${JAR_FILE} /function-controller.jar


### PR DESCRIPTION
`java` image is deprecated.

https://hub.docker.com/_/java/
