### PR TITLE
Cope with function deletion and re-creation in close succession

### DIFF
--- a/cmd/function-controller.go
+++ b/cmd/function-controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/informers/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"time"
 )
 
 func main() {
@@ -54,7 +55,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	ctrl := controller.New(topicsInformer, functionsInformer, deploymentInformer, deployer, controller.NewLagTracker(brokers), 8080)
+	ctrl := controller.New(topicsInformer, functionsInformer, deploymentInformer, deployer, controller.NewLagTracker(brokers), 8080, time.Duration(10*time.Second))
 
 	controller.DecorateWithDelayAndSmoothing(ctrl)
 


### PR DESCRIPTION
`riff update` current provokes the behaviour, but it could happen if a function
was explicitly deleted and then immediated re-created.

The approach is to retry on function-controller's main goroutine. This will
make the main goroutine unresponsive.

An alternative would be to spawn a goroutine to retry and complete the
deployment, but this state would need to be tracked to handle related activity
correctly. This seemed overly complex given function-controller's current
design of taking action on the main goroutine.

Fixes https://github.com/projectriff/function-controller/issues/5