### PR TITLE
Preserve deployment replicas on function update

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -191,7 +191,7 @@ func (c *ctrl) onFunctionUpdated(oldFn *v1.Function, newFn *v1.Function) {
 		c.lagTracker.BeginTracking(Subscription{Topic: newFn.Spec.Input, Group: newFn.Name})
 	}
 
-	err := c.deployer.Update(newFn, 0 /*int(c.actualReplicas[fnKey])*/) // See https://github.com/projectriff/function-controller/issues/17
+	err := c.deployer.Update(newFn, int(c.actualReplicas[fnKey]))
 	if err != nil {
 		log.Printf("Error %v", err)
 	}


### PR DESCRIPTION
With this code change, some updates to a function, such as modifying labels,
cause the deployment to be updated with identical old and new values, and,
consequently, kubernetes does not drive the deployment informer.

Fixes https://github.com/projectriff/function-controller/issues/17